### PR TITLE
[Lint-Workflow] downgraded from ubuntu-latest to v18.04

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -7,8 +7,8 @@ jobs:
   runner:
     name: Runner
 
-    # Runs on latest ubuntu version
-    runs-on: ubuntu-latest
+    # Runs on ubuntu version 18.04
+    runs-on: ubuntu-18.04
     timeout-minutes: 3
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Noticed that every mocha-check is failing due to version incompatibilities. Because of this I think we should lock the ubuntu version here too.