### PR TITLE
Added custom angular material theme

### DIFF
--- a/client/imports/app/app.html
+++ b/client/imports/app/app.html
@@ -1,5 +1,7 @@
 <header-component></header-component>
-<main><router-outlet></router-outlet></main>
+<main>
+  <router-outlet></router-outlet>
+</main>
 <footer-component></footer-component>
 <ng-template #loading>
   <!--TODO: Implement some kind of loading-indicator.-->

--- a/client/imports/app/app.module.ts
+++ b/client/imports/app/app.module.ts
@@ -8,14 +8,13 @@ import { HomeComponent } from './home/home.component'
 import { AccountsModule } from 'angular2-meteor-accounts-ui'
 import { TranslateModule, TranslateLoader } from '@ngx-translate/core'
 import { TranslateHttpLoader } from '@ngx-translate/http-loader'
-import { HttpClientModule, HttpClient } from '@angular/common/http'
-import { HeaderComponent } from './header/header.component'
-import { FooterComponent } from './footer/footer.component'
+import { HttpClient } from '@angular/common/http'
 import { HomeModule } from './home/home.module'
 import { SharedModule } from './shared/shared.module'
 import { HeaderModule } from './header/header.module'
 import { FooterModule } from './footer/footer.module'
 import { PageNotFoundModule } from './page-not-found/page-not-found.module'
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 
 export function createTranslateLoader(http: HttpClient) {
     return new TranslateHttpLoader(http, './assets/i18n/', '.json')
@@ -24,6 +23,7 @@ export function createTranslateLoader(http: HttpClient) {
 @NgModule({
     imports: [
         BrowserModule,
+        BrowserAnimationsModule,
         FormsModule,
         SharedModule,
         RouterModule.forRoot([

--- a/client/imports/app/frame/frame.scss
+++ b/client/imports/app/frame/frame.scss
@@ -4,6 +4,7 @@
   position: relative;
   width: 100%;
   padding-top: 14px;
+  margin-bottom: 14px;
 
   header {
     height: 32px;

--- a/client/imports/styles/_main.scss
+++ b/client/imports/styles/_main.scss
@@ -2,10 +2,16 @@
 
 @import url("/assets/css/reset.css");
 @import url("/assets/css/typography.css");
+@import "theme";
 
 html {
   background-color: color(background, base);
   color: color(foreground, base);
+}
+
+html,
+body {
+  height: 100%;
 }
 
 a {
@@ -40,7 +46,7 @@ table {
       border-bottom-right-radius: 2px;
     }
     td {
-      padding: 12px 5px ;
+      padding: 12px 5px;
       color: color(background, dark);
       background: color(foreground, base);
     }

--- a/client/imports/styles/_theme.scss
+++ b/client/imports/styles/_theme.scss
@@ -1,0 +1,254 @@
+/**
+* Generated theme by Material Theme Generator
+* https://materialtheme.arcsine.dev
+*/
+
+@import "@angular/material/theming";
+// Include the common styles for Angular Material. We include this here so that you only
+// have to load a single css file for Angular Material in your app.
+
+// Fonts
+@import "https://fonts.googleapis.com/css?family=Material+Icons";
+@import url("https://fonts.googleapis.com/css?family=Roboto:300,400,500");
+
+$fontConfig: (
+  display-4: mat-typography-level(112px, 112px, 300, "Roboto", -0.0134em),
+  display-3: mat-typography-level(56px, 56px, 400, "Roboto", -0.0089em),
+  display-2: mat-typography-level(45px, 48px, 400, "Roboto", 0em),
+  display-1: mat-typography-level(34px, 40px, 400, "Roboto", 0.0074em),
+  headline: mat-typography-level(24px, 32px, 400, "Roboto", 0em),
+  title: mat-typography-level(20px, 32px, 500, "Roboto", 0.0075em),
+  subheading-2: mat-typography-level(16px, 28px, 400, "Roboto", 0.0094em),
+  subheading-1: mat-typography-level(15px, 24px, 500, "Roboto", 0.0067em),
+  body-2: mat-typography-level(14px, 24px, 500, "Roboto", 0.0179em),
+  body-1: mat-typography-level(14px, 20px, 400, "Roboto", 0.0179em),
+  button: mat-typography-level(14px, 14px, 500, "Roboto", 0.0893em),
+  caption: mat-typography-level(12px, 20px, 400, "Roboto", 0.0333em),
+  input: mat-typography-level(inherit, 1.125, 400, "Roboto", 1.5px),
+);
+
+// Foreground Elements
+
+// Light Theme Text
+$dark-text: #222831;
+$dark-primary-text: rgba($dark-text, 0.87);
+$dark-accent-text: rgba($dark-primary-text, 0.54);
+$dark-disabled-text: rgba($dark-primary-text, 0.38);
+$dark-dividers: rgba($dark-primary-text, 0.12);
+$dark-focused: rgba($dark-primary-text, 0.12);
+
+$mat-light-theme-foreground: (
+  base: black,
+  divider: $dark-dividers,
+  dividers: $dark-dividers,
+  disabled: $dark-disabled-text,
+  disabled-button: rgba($dark-text, 0.26),
+  disabled-text: $dark-disabled-text,
+  elevation: black,
+  secondary-text: $dark-accent-text,
+  hint-text: $dark-disabled-text,
+  accent-text: $dark-accent-text,
+  icon: $dark-accent-text,
+  icons: $dark-accent-text,
+  text: $dark-primary-text,
+  slider-min: $dark-primary-text,
+  slider-off: rgba($dark-text, 0.26),
+  slider-off-active: $dark-disabled-text,
+);
+
+// Dark Theme text
+$light-text: #eeeeee;
+$light-primary-text: $light-text;
+$light-accent-text: rgba($light-primary-text, 0.7);
+$light-disabled-text: rgba($light-primary-text, 0.5);
+$light-dividers: rgba($light-primary-text, 0.12);
+$light-focused: rgba($light-primary-text, 0.12);
+
+$mat-dark-theme-foreground: (
+  base: $light-text,
+  divider: $light-dividers,
+  dividers: $light-dividers,
+  disabled: $light-disabled-text,
+  disabled-button: rgba($light-text, 0.3),
+  disabled-text: $light-disabled-text,
+  elevation: black,
+  hint-text: $light-disabled-text,
+  secondary-text: $light-accent-text,
+  accent-text: $light-accent-text,
+  icon: $light-text,
+  icons: $light-text,
+  text: $light-text,
+  slider-min: $light-text,
+  slider-off: rgba($light-text, 0.3),
+  slider-off-active: rgba($light-text, 0.3),
+);
+
+// Background config
+// Light bg
+$light-background: #eeeeee;
+$light-bg-darker-5: darken($light-background, 5%);
+$light-bg-darker-10: darken($light-background, 10%);
+$light-bg-darker-20: darken($light-background, 20%);
+$light-bg-darker-30: darken($light-background, 30%);
+$light-bg-lighter-5: lighten($light-background, 5%);
+$dark-bg-tooltip: lighten(#393e46, 20%);
+$dark-bg-alpha-4: rgba(#393e46, 0.04);
+$dark-bg-alpha-12: rgba(#393e46, 0.12);
+
+$mat-light-theme-background: (
+  background: $light-background,
+  status-bar: $light-bg-darker-20,
+  app-bar: $light-bg-darker-5,
+  hover: $dark-bg-alpha-4,
+  card: $light-bg-lighter-5,
+  dialog: $light-bg-lighter-5,
+  tooltip: $dark-bg-tooltip,
+  disabled-button: $dark-bg-alpha-12,
+  raised-button: $light-bg-lighter-5,
+  focused-button: $dark-focused,
+  selected-button: $light-bg-darker-20,
+  selected-disabled-button: $light-bg-darker-30,
+  disabled-button-toggle: $light-bg-darker-10,
+  unselected-chip: $light-bg-darker-10,
+  disabled-list-option: $light-bg-darker-10,
+);
+
+// Dark bg
+$dark-background: #393e46;
+$dark-bg-lighter-5: lighten($dark-background, 5%);
+$dark-bg-lighter-10: lighten($dark-background, 10%);
+$dark-bg-lighter-20: lighten($dark-background, 20%);
+$dark-bg-lighter-30: lighten($dark-background, 30%);
+$light-bg-alpha-4: rgba(#eeeeee, 0.04);
+$light-bg-alpha-12: rgba(#eeeeee, 0.12);
+
+// Background palette for dark themes.
+$mat-dark-theme-background: (
+  background: $dark-background,
+  status-bar: $dark-bg-lighter-20,
+  app-bar: $dark-bg-lighter-5,
+  hover: $light-bg-alpha-4,
+  card: $dark-bg-lighter-5,
+  dialog: $dark-bg-lighter-5,
+  tooltip: $dark-bg-lighter-20,
+  disabled-button: $light-bg-alpha-12,
+  raised-button: $dark-bg-lighter-5,
+  focused-button: $light-focused,
+  selected-button: $dark-bg-lighter-20,
+  selected-disabled-button: $dark-bg-lighter-30,
+  disabled-button-toggle: $dark-bg-lighter-10,
+  unselected-chip: $dark-bg-lighter-20,
+  disabled-list-option: $dark-bg-lighter-10,
+);
+
+// Compute font config
+@include mat-core($fontConfig);
+
+// Theme Config
+
+body {
+  --primary-color: #ffd320;
+  --primary-lighter-color: #fff2bc;
+  --primary-darker-color: #ffc213;
+  --text-primary-color: #{$dark-primary-text};
+  --text-primary-lighter-color: #{$dark-primary-text};
+  --text-primary-darker-color: #{$dark-primary-text};
+}
+
+$mat-primary: (
+  main: #ffd320,
+  lighter: #fff2bc,
+  darker: #ffc213,
+  200: #ffd320,
+  // For slide toggle,
+    contrast:
+    (
+      main: $dark-primary-text,
+      lighter: $dark-primary-text,
+      darker: $dark-primary-text,
+    ),
+);
+$theme-primary: mat-palette($mat-primary, main, lighter, darker);
+
+body {
+  --accent-color: #ff5722;
+  --accent-lighter-color: #ffcdbd;
+  --accent-darker-color: #ff3c14;
+  --text-accent-color: #{$dark-primary-text};
+  --text-accent-lighter-color: #{$dark-primary-text};
+  --text-accent-darker-color: #{$light-primary-text};
+}
+
+$mat-accent: (
+  main: #ff5722,
+  lighter: #ffcdbd,
+  darker: #ff3c14,
+  200: #ff5722,
+  // For slide toggle,
+    contrast:
+    (
+      main: $dark-primary-text,
+      lighter: $dark-primary-text,
+      darker: $light-primary-text,
+    ),
+);
+$theme-accent: mat-palette($mat-accent, main, lighter, darker);
+
+body {
+  --warn-color: #ff0000;
+  --warn-lighter-color: #ffb3b3;
+  --warn-darker-color: #ff0000;
+  --text-warn-color: #{$light-primary-text};
+  --text-warn-lighter-color: #{$dark-primary-text};
+  --text-warn-darker-color: #{$light-primary-text};
+}
+
+$mat-warn: (
+  main: #ff0000,
+  lighter: #ffb3b3,
+  darker: #ff0000,
+  200: #ff0000,
+  // For slide toggle,
+    contrast:
+    (
+      main: $light-primary-text,
+      lighter: $dark-primary-text,
+      darker: $light-primary-text,
+    ),
+);
+$theme-warn: mat-palette($mat-warn, main, lighter, darker);
+
+$theme: mat-dark-theme($theme-primary, $theme-accent, $theme-warn);
+$altTheme: mat-light-theme($theme-primary, $theme-accent, $theme-warn);
+
+// Theme Init
+@include angular-material-theme($theme);
+
+.theme-alternate {
+  @include angular-material-theme($altTheme);
+}
+
+// Specific component overrides, pieces that are not in line with the general theming
+
+// Handle buttons appropriately, with respect to line-height
+.mat-raised-button,
+.mat-stroked-button,
+.mat-flat-button {
+  padding: 0 1.15em;
+  margin: 0 0.65em;
+  min-width: 3em;
+  line-height: 36.4px;
+}
+
+.mat-standard-chip {
+  padding: 0.5em 0.85em;
+  min-height: 2.5em;
+}
+
+.material-icons {
+  font-size: 24px;
+  font-family: "Material Icons", "Material Icons";
+  .mat-badge-content {
+    font-family: "Roboto";
+  }
+}

--- a/client/main.html
+++ b/client/main.html
@@ -2,11 +2,7 @@
   <base href="/" />
   <title>AMe-Forum</title>
   <link
-    rel="stylesheet"
-    href="http://ajax.googleapis.com/ajax/libs/angular_material/1.1.0/angular-material.min.css"
-  />
-  <link
-    href="https://fonts.googleapis.com/icon?family=Material+Icons"
+    href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined"
     rel="stylesheet"
   />
   <link
@@ -15,6 +11,6 @@
   />
 </head>
 
-<body>
+<body class="mat-app-background">
   <angular-app></angular-app>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,9 +3,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@angular/animations": {
-      "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-9.1.7.tgz",
-      "integrity": "sha512-1wW8ndGMLDuE2LpTN2RNRz1Dt7JgVBeVmOPMgzoA7g1uuvm+jESTrGG7W3BzLzG0BE2TeXt0fY90o4iU+S2Rmg=="
+      "version": "9.1.11",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-9.1.11.tgz",
+      "integrity": "sha512-VKAExUnEJfo1PDQKagpx2pn+QMZCsPLRiADzTdl4U0VPylK3ALbn4ZNY9UbdwyE2plitz++LkH7sEGGfh+PNrQ=="
     },
     "@angular/cdk": {
       "version": "9.2.3",
@@ -56,9 +56,9 @@
       "integrity": "sha512-Njt+pMLfPBchL0/ayIjJqXL6ZfM4Ccvf7KO1wS1HMzh3QlmfNa0JSgc4pfrbRJAMN9g7V/FYLyKejs1bJZkenA=="
     },
     "@angular/material": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-9.2.3.tgz",
-      "integrity": "sha512-QJltLNp8a/eoozPgkFLISEWgdlX9q9+fZaLJ8c9tHEp2IT5sFYBFHf8dPl0pUyxgOXkS/0HD43I1qki71/T7Kw=="
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-9.2.4.tgz",
+      "integrity": "sha512-LkoTXE6B0slvMhvfZDdPWaz4yaYLkaAp5VSPunI9pxGsPxzqEV9e210wC1/sjG/76Nk8Ep7/2z9XKac8Q9bMwA=="
     },
     "@angular/platform-browser": {
       "version": "9.1.4",

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
     "lint-fix": "npx tslint --fix -p tsconfig.json"
   },
   "dependencies": {
-    "@angular/animations": "^9.1.7",
+    "@angular/animations": "^9.1.11",
     "@angular/cdk": "^9.2.3",
     "@angular/common": "9.1.4",
     "@angular/compiler": "9.1.4",
     "@angular/core": "9.1.4",
     "@angular/forms": "9.1.4",
-    "@angular/material": "^9.2.3",
+    "@angular/material": "^9.2.4",
     "@angular/platform-browser": "9.1.4",
     "@angular/platform-browser-dynamic": "9.1.4",
     "@angular/router": "9.1.4",

--- a/public/assets/css/typography.css
+++ b/public/assets/css/typography.css
@@ -1,4 +1,5 @@
 html {
+  font-family: Roboto;
   font-style: normal;
   font-weight: normal;
   font-size: 18px;


### PR DESCRIPTION
# What this PR does

This PR introduces a new custom theme for angular material which should in future components replace the *colors*-css.

## Why this is important

Due to the nearing deadline we have to use premade components to speed up development process. This enables us to do so without having a huge negative impact on visuals.