### PR TITLE
Implementation of #36 - Widget for showing threads

### DIFF
--- a/client/imports/app/forum/forum.html
+++ b/client/imports/app/forum/forum.html
@@ -9,6 +9,6 @@
   </header>
   <mat-divider></mat-divider>
   <main>
-    <threads-widget [forumID]="forum?._id"></threads-widget>
+    <threads-widget [forumId]="forum?._id"></threads-widget>
   </main>
 </article>

--- a/client/imports/app/forum/forum.html
+++ b/client/imports/app/forum/forum.html
@@ -9,6 +9,6 @@
   </header>
   <mat-divider></mat-divider>
   <main>
-    <!-- Threads can be placed here -->
+    <threads-widget [forumID]="forum?._id"></threads-widget>
   </main>
 </article>

--- a/client/imports/app/forum/forum.module.ts
+++ b/client/imports/app/forum/forum.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from "@angular/core"
 import { ForumComponent } from './forum.component'
 import { SharedModule } from '../shared/shared.module'
 import { MatDividerModule } from '@angular/material/divider'
+import { ThreadsWidgetModule } from '../threads-widget/threads-widget.module'
 
 @NgModule({
     declarations: [
@@ -9,7 +10,8 @@ import { MatDividerModule } from '@angular/material/divider'
     ],
     imports: [
         SharedModule,
-        MatDividerModule
+        MatDividerModule,
+        ThreadsWidgetModule
     ],
     exports: [
         ForumComponent

--- a/client/imports/app/forums-widget/forums-widget.component.ts
+++ b/client/imports/app/forums-widget/forums-widget.component.ts
@@ -20,7 +20,7 @@ export class ForumsWidgetComponent implements OnInit, OnDestroy  {
 
     ngOnInit() {
         this.forumListSubscription = MeteorObservable.subscribe('forums').subscribe(() => {
-            this.forums = Forums.find({ }, { sort: { name: 1}})
+            this.forums = Forums.find({ active: true }, { sort: { name: 1}})
             this.changeDetectorRef.markForCheck()
         })
     }

--- a/client/imports/app/forums-widget/forums-widget.html
+++ b/client/imports/app/forums-widget/forums-widget.html
@@ -1,5 +1,5 @@
 <frame-component title="{{ 'widgets.forums.title' | translate }}">
-  <table>
+  <table *ngIf="(forums | async)?.length>0; else loading">
     <thead>
       <tr>
         <th>{{ 'widgets.forums.table.header.name' | translate }}</th>
@@ -17,3 +17,7 @@
     </tbody>
   </table>
 </frame-component>
+
+<ng-template #loading>
+  {{ 'widgets.forums.msg.no-active-forums' | translate }}
+</ng-template>

--- a/client/imports/app/new-forum/new-forum.component.ts
+++ b/client/imports/app/new-forum/new-forum.component.ts
@@ -26,7 +26,8 @@ onSubmit() {
     // fehlender Berechtigungscheck
     const formValue = this.myForm.value
     if (formValue.title !== '' && formValue.description !== '') {
-        const forumId = Meteor.call("createForum", formValue.titel, formValue.beschreibung)
+        // TODO: Implement Response-check
+        const response = Meteor.call("createForum", formValue.titel, formValue.beschreibung)
         this.router.navigateByUrl('/home')
     }
     else {

--- a/client/imports/app/threads-widget/threads-widget.component.spec.ts
+++ b/client/imports/app/threads-widget/threads-widget.component.spec.ts
@@ -1,0 +1,29 @@
+import '../../polyfills.spec'
+
+import { ThreadsWidgetModule } from "./threads-widget.module"
+import { TestBed, getTestBed, async } from '@angular/core/testing'
+import { ThreadsWidgetComponent } from './threads-widget.component'
+import { expect } from 'chai'
+import { TranslateModule } from '@ngx-translate/core'
+
+describe(`ThreadsWidgetComponent`, () => {
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                ThreadsWidgetModule,
+                TranslateModule.forRoot({ })
+            ]
+        }).compileComponents() // compile html and css
+    }))
+
+    afterEach(() => {
+        getTestBed().resetTestingModule()
+    })
+
+    it('should create the component', async(() => {
+        const fixture = TestBed.createComponent(ThreadsWidgetComponent)
+        const ThreadsWidget = fixture.debugElement.componentInstance
+        expect(ThreadsWidget).to.be.ok
+    }))
+
+})

--- a/client/imports/app/threads-widget/threads-widget.component.ts
+++ b/client/imports/app/threads-widget/threads-widget.component.ts
@@ -1,0 +1,39 @@
+import { Component, ChangeDetectionStrategy, TemplateRef, ChangeDetectorRef, OnDestroy, OnInit, Input } from "@angular/core"
+
+import { Observable, Subscription } from 'rxjs'
+import { MeteorObservable } from 'meteor-rxjs'
+
+import { Threads } from '../../../../imports/collections/threads'
+import { Thread } from '../../../../imports/models/thread'
+
+@Component({
+  selector: "threads-widget",
+  templateUrl: "./threads-widget.html",
+  styleUrls: ["./threads-widget.scss"],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ThreadsWidgetComponent implements OnInit, OnDestroy  {
+    @Input() forumID
+
+    threads: Observable<Thread[]>
+    threadListSubscription: Subscription
+
+    constructor(private changeDetectorRef: ChangeDetectorRef) { }
+
+    ngOnInit() {
+        this.threadListSubscription = MeteorObservable.subscribe('threads').subscribe(() => {
+            this.threads = Threads.find({ forumID: this.forumID }, { sort: { date: 1}})
+            this.changeDetectorRef.markForCheck()
+        })
+    }
+
+    ngOnDestroy() {
+        if (this.threadListSubscription) {
+            this.threadListSubscription.unsubscribe()
+        }
+    }
+
+    identify(índex, item: Thread) {
+        return item._id
+    }
+}

--- a/client/imports/app/threads-widget/threads-widget.component.ts
+++ b/client/imports/app/threads-widget/threads-widget.component.ts
@@ -13,7 +13,7 @@ import { Thread } from '../../../../imports/models/thread'
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ThreadsWidgetComponent implements OnInit, OnDestroy  {
-    @Input() forumID
+    @Input() forumId
 
     threads: Observable<Thread[]>
     threadListSubscription: Subscription
@@ -22,7 +22,7 @@ export class ThreadsWidgetComponent implements OnInit, OnDestroy  {
 
     ngOnInit() {
         this.threadListSubscription = MeteorObservable.subscribe('threads').subscribe(() => {
-            this.threads = Threads.find({ forumID: this.forumID }, { sort: { date: 1}})
+            this.threads = Threads.find({ forumId: this.forumId }, { sort: { date: 1}})
             this.changeDetectorRef.markForCheck()
         })
     }

--- a/client/imports/app/threads-widget/threads-widget.html
+++ b/client/imports/app/threads-widget/threads-widget.html
@@ -1,0 +1,29 @@
+<frame-component title="{{ 'widgets.threads.title' | translate }}">
+  <table *ngIf="(threads | async)?.length>0; else loading">
+    <thead>
+      <tr>
+        <th>{{ 'widgets.threads.table.header.name' | translate }}</th>
+        <th>{{ 'widgets.threads.table.header.creator' | translate }}</th>
+        <th>{{ 'widgets.threads.table.header.views' | translate }}</th>
+        <th>{{ 'widgets.threads.table.header.follows' | translate }}</th>
+        <th>{{ 'widgets.threads.table.header.date' | translate }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        *ngFor="let thread of threads | async; trackBy: identify"
+        routerLink="/forum/{{ forumID }}/{{ thread._id }}"
+      >
+        <td>{{ thread.name }}</td>
+        <td>{{ thread.creator }}</td>
+        <td>{{ thread.viewCounter }}</td>
+        <td>{{ thread.followCounter }}</td>
+        <td>{{ thread.date }}</td>
+      </tr>
+    </tbody>
+  </table>
+</frame-component>
+
+<ng-template #loading>
+  {{ 'widgets.threads.msg.no-threads-in-forum' | translate }}
+</ng-template>

--- a/client/imports/app/threads-widget/threads-widget.module.ts
+++ b/client/imports/app/threads-widget/threads-widget.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core'
+import { SharedModule } from '../shared/shared.module'
+import { ThreadsWidgetComponent } from './threads-widget.component'
+import { FrameModule } from '../frame/frame.module'
+import { RouterModule } from '@angular/router'
+
+@NgModule({
+    declarations: [
+        ThreadsWidgetComponent
+    ],
+    imports: [
+        SharedModule,
+        FrameModule,
+        RouterModule
+    ],
+    exports: [
+        ThreadsWidgetComponent
+    ]
+})
+export class ThreadsWidgetModule { }

--- a/client/imports/app/threads-widget/threads-widget.scss
+++ b/client/imports/app/threads-widget/threads-widget.scss
@@ -1,0 +1,3 @@
+tbody tr:hover {
+  cursor: pointer;
+}

--- a/public/assets/i18n/en.json
+++ b/public/assets/i18n/en.json
@@ -8,6 +8,9 @@
   "widgets": {
     "forums": {
       "title": "Forums",
+      "msg": {
+        "no-active-forums": "There currently aren't any active forums."
+      },
       "table": {
         "header": {
           "name": "Name",
@@ -15,7 +18,22 @@
         }
       }
     },
-    "new-forum":{
+    "threads": {
+      "title": "Threads",
+      "msg": {
+        "no-threads-in-forum": "There currently aren't any threads in this forum."
+      },
+      "table": {
+        "header": {
+          "name": "Name",
+          "creator": "Creator",
+          "views": "Views",
+          "follows": "Follows",
+          "date": "Created on"
+        }
+      }
+    },
+    "new-forum": {
       "title": "Create Forum",
       "form": {
         "inputs": {
@@ -30,13 +48,11 @@
           "submit": {
             "label": "Create"
           }
-
         }
       }
     },
-    "loginRegistration":{
+    "loginRegistration": {
       "title": "Login / Registration"
     }
-    
   }
 }

--- a/server/imports/methods/forums.ts
+++ b/server/imports/methods/forums.ts
@@ -31,6 +31,5 @@ Meteor.methods({
       name: _forumName,
       description: _description
     })
-    // const id = Forums.find({_id: "TrYfp7JsvQTitC6X7"},{_id:1})
   }
 })


### PR DESCRIPTION
# What this PR does

This PR introduces a widget for showing the threads (inactive and active) of a given forum. It also includes routerlinks to them (target not yet implemented).  
This is similar to #26.

- fixes #36

[Create a module for displaying threads](https://app.gitkraken.com/glo/board/5ead65ff6cb04e00112b0b5f/card/5ec32921a24f5a0011825c0e)