### PR TITLE
Implementation of #60 and others - Thread-Page, Markdown-Interpreter, Module for displaying Posts

### DIFF
--- a/client/imports/app/app.module.ts
+++ b/client/imports/app/app.module.ts
@@ -24,6 +24,7 @@ import { AdminModule } from './admin/admin.module'
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 import { ThreadComponent } from './thread/thread.component'
 import { ThreadModule } from './thread/thread.module'
+import { MarkedPipe } from './shared/marked.pipe'
 
 export function createTranslateLoader(http: HttpClient) {
     return new TranslateHttpLoader(http, './assets/i18n/', '.json')

--- a/client/imports/app/app.module.ts
+++ b/client/imports/app/app.module.ts
@@ -22,6 +22,8 @@ import { NewThreadModule } from './new-thread/new-thread.module'
 import { AdminComponent } from './admin/admin.component'
 import { AdminModule } from './admin/admin.module'
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
+import { ThreadComponent } from './thread/thread.component'
+import { ThreadModule } from './thread/thread.module'
 
 export function createTranslateLoader(http: HttpClient) {
     return new TranslateHttpLoader(http, './assets/i18n/', '.json')
@@ -49,9 +51,14 @@ export function createTranslateLoader(http: HttpClient) {
                 canActivate: [AuthGuard]
             },
             {
+                path: 'forum/:forumId/thread/:id',
+                component: ThreadComponent
+            },
+            {
                 path: 'forum/:id',
                 component: ForumComponent
-            },
+            }
+            ,
             {
                 path: 'new-forum',
                 component: NewForumComponent
@@ -82,7 +89,8 @@ export function createTranslateLoader(http: HttpClient) {
         PageNotFoundModule,
         NewThreadModule,
         AdminModule,
-        NewForumModule
+        NewForumModule,
+        ThreadModule
     ],
     declarations: [
         AppComponent

--- a/client/imports/app/frame/frame.scss
+++ b/client/imports/app/frame/frame.scss
@@ -3,27 +3,26 @@
 .frame {
   position: relative;
   width: 100%;
-  padding-top: 14px;
+  padding-top: 13.5px;
   margin-bottom: 14px;
 
-  header {
-    height: 32px;
+  > header {
     left: 7px;
     top: 0px;
     position: absolute;
-    padding-left: 2px;
-    padding-right: 2px;
+    padding-left: 8px;
+    padding-right: 8px;
     background-color: color(background, base);
     z-index: 1;
 
-    h1 {
-      font-size: 24px;
-      line-height: 28px;
+    > h1 {
+      font-size: 27px;
       color: color(accent, base);
+      margin: 0;
     }
   }
 
-  main {
+  > main {
     z-index: 0;
     padding: 20px 15px;
     border: 1px solid color(foreground, base);

--- a/client/imports/app/home/home.component.spec.ts
+++ b/client/imports/app/home/home.component.spec.ts
@@ -11,15 +11,15 @@ import { SharedModule } from '../shared/shared.module'
 import { LoginRegistrationComponent } from '../login-registration/login-registration.component'
 import { RouterTestingModule } from '@angular/router/testing'
 import { FrameComponent } from '../frame/frame.component'
-import { HomeModule } from './home.module'
+import { MatDivider } from '@angular/material/divider'
 
 describe(`HomeComponent`, () => {
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            declarations: [MockComponent(ForumsWidgetComponent), MockComponent(ForumsWidgetComponent), MockComponent(LoginRegistrationComponent), MockComponent(FrameComponent)],
+            declarations: [HomeComponent, MockComponent(ForumsWidgetComponent), MockComponent(ForumsWidgetComponent), MockComponent(LoginRegistrationComponent), MockComponent(FrameComponent)],
             imports: [
+                MatDivider,
                 RouterTestingModule,
-                HomeModule,
                 SharedModule,
                 TranslateModule.forRoot({ })
             ]

--- a/client/imports/app/home/home.component.spec.ts
+++ b/client/imports/app/home/home.component.spec.ts
@@ -11,13 +11,15 @@ import { SharedModule } from '../shared/shared.module'
 import { LoginRegistrationComponent } from '../login-registration/login-registration.component'
 import { RouterTestingModule } from '@angular/router/testing'
 import { FrameComponent } from '../frame/frame.component'
+import { HomeModule } from './home.module'
 
 describe(`HomeComponent`, () => {
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            declarations: [HomeComponent, MockComponent(ForumsWidgetComponent), MockComponent(ForumsWidgetComponent), MockComponent(LoginRegistrationComponent), MockComponent(FrameComponent)],
+            declarations: [MockComponent(ForumsWidgetComponent), MockComponent(ForumsWidgetComponent), MockComponent(LoginRegistrationComponent), MockComponent(FrameComponent)],
             imports: [
                 RouterTestingModule,
+                HomeModule,
                 SharedModule,
                 TranslateModule.forRoot({ })
             ]

--- a/client/imports/app/home/home.component.spec.ts
+++ b/client/imports/app/home/home.component.spec.ts
@@ -11,14 +11,14 @@ import { SharedModule } from '../shared/shared.module'
 import { LoginRegistrationComponent } from '../login-registration/login-registration.component'
 import { RouterTestingModule } from '@angular/router/testing'
 import { FrameComponent } from '../frame/frame.component'
-import { MatDivider } from '@angular/material/divider'
+import { MatDividerModule } from '@angular/material/divider'
 
 describe(`HomeComponent`, () => {
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             declarations: [HomeComponent, MockComponent(ForumsWidgetComponent), MockComponent(ForumsWidgetComponent), MockComponent(LoginRegistrationComponent), MockComponent(FrameComponent)],
             imports: [
-                MatDivider,
+                MatDividerModule,
                 RouterTestingModule,
                 SharedModule,
                 TranslateModule.forRoot({ })

--- a/client/imports/app/home/home.html
+++ b/client/imports/app/home/home.html
@@ -1,20 +1,28 @@
-<aside>
-  <login-registration-component></login-registration-component>
-  <frame-component
-    *ngIf="user"
-    title="{{ 'widgets.actions.title' | translate }}"
-  >
-    <button
-      *ngIf="user?.roles?.includes('admin')"
-      [routerLink]="['/admin']"
-      style="width: 100%;"
-      mat-flat-button
-      color="accent"
-    >
-      {{ 'pages.admin.navigateTo' | translate }}
-    </button>
-  </frame-component>
-</aside>
-<main>
-  <forums-widget></forums-widget>
-</main>
+<article>
+  <header>
+    <h1>{{ 'pages.home' | translate }}</h1>
+    <mat-divider></mat-divider>
+  </header>
+  <main>
+    <aside>
+      <login-registration-component></login-registration-component>
+      <frame-component
+        *ngIf="user"
+        title="{{ 'widgets.actions.title' | translate }}"
+      >
+        <button
+          *ngIf="user?.roles?.includes('admin')"
+          [routerLink]="['/admin']"
+          style="width: 100%;"
+          mat-flat-button
+          color="accent"
+        >
+          {{ 'pages.admin.navigateTo' | translate }}
+        </button>
+      </frame-component>
+    </aside>
+    <main>
+      <forums-widget></forums-widget>
+    </main>
+  </main>
+</article>

--- a/client/imports/app/home/home.module.ts
+++ b/client/imports/app/home/home.module.ts
@@ -6,6 +6,7 @@ import { LoginRegistrationModule } from '../login-registration/login-registratio
 import { MatButtonModule } from '@angular/material/button'
 import { FrameModule } from '../frame/frame.module'
 import { RouterModule } from '@angular/router'
+import { MatDividerModule } from '@angular/material/divider'
 
 @NgModule({
     declarations: [
@@ -17,7 +18,8 @@ import { RouterModule } from '@angular/router'
         ForumsWidgetModule,
         MatButtonModule,
         FrameModule,
-        RouterModule
+        RouterModule,
+        MatDividerModule
     ],
     exports: [
         HomeComponent

--- a/client/imports/app/home/home.scss
+++ b/client/imports/app/home/home.scss
@@ -3,46 +3,51 @@
 :host {
   @extend .content-flex-container;
 
-  @media only screen and (min-width: 900px) {
-    flex-direction: row;
+  > article > main {
+    display: flex;
+    flex-direction: column;
 
-    > {
-      // This adds spacing between the elements (empty ones get ignored)
-      *:not(:empty) ~ *:not(:empty) {
-        border-left: 24px solid transparent;
-        border-top: initial !important;
+    @media only screen and (min-width: 900px) {
+      flex-direction: row;
+
+      > {
+        // This adds spacing between the elements (empty ones get ignored)
+        *:not(:empty) ~ *:not(:empty) {
+          border-left: 24px solid transparent;
+          border-top: initial !important;
+        }
       }
     }
-  }
 
-  > {
-    * {
-      flex: 1;
-      overflow-wrap: break-word;
-      background-clip: padding-box;
-    }
+    > {
+      * {
+        flex: 1;
+        overflow-wrap: break-word;
+        background-clip: padding-box;
+      }
 
-    *:empty {
-      display: none;
-    }
+      *:empty {
+        display: none;
+      }
 
-    // This adds spacing between the elements (empty ones get ignored)
-    *:not(:empty) ~ *:not(:empty) {
-      border-top: 12px solid transparent;
-    }
-
-    aside {
-      flex: 0.5;
-    }
-
-    aside,
-    main {
-      display: flex;
-      flex-direction: column;
-
-      // Smaller spacing inside
+      // This adds spacing between the elements (empty ones get ignored)
       *:not(:empty) ~ *:not(:empty) {
-        border-top: 10px solid transparent;
+        border-top: 12px solid transparent;
+      }
+
+      aside {
+        flex: 0.5;
+      }
+
+      aside,
+      main {
+        display: flex;
+        flex-direction: column;
+
+        // Smaller spacing inside
+        *:not(:empty) ~ *:not(:empty) {
+          border-top: 10px solid transparent;
+        }
       }
     }
   }

--- a/client/imports/app/new-thread/new-thread.component.ts
+++ b/client/imports/app/new-thread/new-thread.component.ts
@@ -15,10 +15,15 @@ export class NewThreadComponent implements OnInit{
     @Input() forumId
 
     myForm: FormGroup
+    user: Meteor.User
 
     constructor(private fb: FormBuilder) { }
 
     ngOnInit() {
+        Tracker.autorun(() => {
+            this.user = Meteor.user()
+        })
+
         this.myForm = this.fb.group({
             title: '',
             text: ''

--- a/client/imports/app/new-thread/new-thread.html
+++ b/client/imports/app/new-thread/new-thread.html
@@ -1,5 +1,5 @@
 <frame-component title="{{ 'widgets.new-thread.title' | translate }}">
-    <form [formGroup]="myForm">
+    <form *ngIf="user; else loggedOut" [formGroup]="myForm">
       <mat-form-field>
         <mat-label>{{ 'widgets.new-thread.form.inputs.title.label' | translate }}</mat-label>
         <input matInput placeholder="{{ 'widgets.new-thread.form.inputs.title.placeholder' | translate }}" formControlName="title" required>
@@ -11,3 +11,7 @@
       <button mat-flat-button color="accent" (click)="onSubmit()">{{ 'widgets.new-thread.form.inputs.submit.label' | translate }}</button>
     </form>
 </frame-component>
+
+<ng-template #loggedOut>
+  {{ 'widgets.new-thread.msg.must-be-signed-in' | translate }}
+</ng-template>

--- a/client/imports/app/posts/posts.component.spec.ts
+++ b/client/imports/app/posts/posts.component.spec.ts
@@ -1,0 +1,29 @@
+import '../../polyfills.spec'
+
+import { PostsModule } from "./posts.module"
+import { TestBed, getTestBed, async } from '@angular/core/testing'
+import { PostsComponent } from './posts.component'
+import { expect } from 'chai'
+import { TranslateModule } from '@ngx-translate/core'
+
+describe(`PostComponent`, () => {
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                PostsModule,
+                TranslateModule.forRoot({ })
+            ]
+        }).compileComponents() // compile html and css
+    }))
+
+    afterEach(() => {
+        getTestBed().resetTestingModule()
+    })
+
+    it('should create the component', async(() => {
+        const fixture = TestBed.createComponent(PostsComponent)
+        const posts = fixture.debugElement.componentInstance
+        expect(posts).to.be.ok
+    }))
+
+})

--- a/client/imports/app/posts/posts.component.ts
+++ b/client/imports/app/posts/posts.component.ts
@@ -1,0 +1,39 @@
+import { Component, ChangeDetectionStrategy, TemplateRef, ChangeDetectorRef, OnDestroy, OnInit, Input } from "@angular/core"
+
+import { Observable, Subscription } from 'rxjs'
+import { MeteorObservable } from 'meteor-rxjs'
+
+import { Posts } from '../../../../imports/collections/posts'
+import { Post } from '../../../../imports/models/post'
+
+@Component({
+  selector: "posts-component",
+  templateUrl: "./posts.html",
+  styleUrls: ["./posts.scss"],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PostsComponent implements OnInit, OnDestroy  {
+    @Input() threadId
+
+    posts: Observable<Post[]>
+    threadListSubscription: Subscription
+
+    constructor(private changeDetectorRef: ChangeDetectorRef) { }
+
+    ngOnInit() {
+        this.threadListSubscription = MeteorObservable.subscribe('posts').subscribe(() => {
+            this.posts = Posts.find({ threadId: this.threadId }, { sort: { date: 1}})
+            this.changeDetectorRef.markForCheck()
+        })
+    }
+
+    ngOnDestroy() {
+        if (this.threadListSubscription) {
+            this.threadListSubscription.unsubscribe()
+        }
+    }
+
+    identify(índex, item: Post) {
+        return item._id
+    }
+}

--- a/client/imports/app/posts/posts.html
+++ b/client/imports/app/posts/posts.html
@@ -1,6 +1,6 @@
 <div *ngFor="let post of posts | async | slice :0:1; trackBy: identify">
   <frame-component
-    title="{{ post.userId }} @ {{ post.postTime.toLocaleDateString() }}"
+    title="{{ post.userId }} @ {{ post.postTime | date: 'medium' }}"
   >
     <article>
       <main class="markdown-body" [innerHTML]="post.comment | marked"></main>
@@ -19,7 +19,7 @@
     <article>
       <header>
         <h2>{{ post.userId }}</h2>
-        <p>@ {{ post.postTime.toLocaleString() }}</p>
+        <p>@ {{ post.postTime | date: 'medium' }}</p>
       </header>
       <main [innerHTML]="post.comment | marked"></main>
     </article>

--- a/client/imports/app/posts/posts.html
+++ b/client/imports/app/posts/posts.html
@@ -1,0 +1,31 @@
+<div *ngFor="let post of posts | async | slice :0:1; trackBy: identify">
+  <frame-component
+    title="{{ post.userId }} @ {{ post.postTime.toLocaleDateString() }}"
+  >
+    <article>
+      <main class="markdown-body" [innerHTML]="post.comment | marked"></main>
+    </article>
+  </frame-component>
+</div>
+
+<frame-component
+  *ngIf="(posts | async)?.length > 1; else loading"
+  title="{{ 'pages.thread.answers.title' | translate }}"
+>
+  <div
+    *ngFor="let post of posts | async | slice :1; trackBy: identify; let indexOfElement = index;"
+  >
+    <mat-divider *ngIf="indexOfElement > 0"></mat-divider>
+    <article>
+      <header>
+        <h2>{{ post.userId }}</h2>
+        <p>@ {{ post.postTime.toLocaleString() }}</p>
+      </header>
+      <main [innerHTML]="post.comment | marked"></main>
+    </article>
+  </div>
+</frame-component>
+
+<ng-template #loading>
+  <p>{{ 'pages.thread.answers.empty' | translate }}</p>
+</ng-template>

--- a/client/imports/app/posts/posts.module.ts
+++ b/client/imports/app/posts/posts.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core'
+import { SharedModule } from '../shared/shared.module'
+import { PostsComponent } from './posts.component'
+import { FrameModule } from '../frame/frame.module'
+import { RouterModule } from '@angular/router'
+import { MarkedPipe } from '../shared/marked.pipe'
+import { MatDividerModule } from '@angular/material/divider'
+
+@NgModule({
+    declarations: [
+        PostsComponent
+    ],
+    imports: [
+        SharedModule,
+        FrameModule,
+        RouterModule,
+        MatDividerModule
+    ],
+    exports: [
+        PostsComponent
+    ]
+})
+export class PostsModule { }

--- a/client/imports/app/posts/posts.scss
+++ b/client/imports/app/posts/posts.scss
@@ -1,0 +1,1 @@
+@import "../shared/shared";

--- a/client/imports/app/shared/marked.pipe.ts
+++ b/client/imports/app/shared/marked.pipe.ts
@@ -1,0 +1,14 @@
+import { Pipe, PipeTransform } from "@angular/core"
+import * as marked from "marked"
+
+@Pipe({
+  name: "marked"
+})
+export class MarkedPipe implements PipeTransform {
+  transform(value: any): any {
+    if (value && value.length > 0) {
+      return marked(value)
+    }
+    return value
+  }
+}

--- a/client/imports/app/shared/shared.module.ts
+++ b/client/imports/app/shared/shared.module.ts
@@ -2,14 +2,19 @@ import { NgModule } from "@angular/core"
 import { TranslateModule } from '@ngx-translate/core'
 import { CommonModule } from '@angular/common'
 import { HttpClientModule } from '@angular/common/http'
+import { MarkedPipe } from './marked.pipe'
 
 @NgModule({
+    declarations: [
+        MarkedPipe
+    ],
     exports: [
         // angular modules
         CommonModule,
         HttpClientModule,
         // third party modules
-        TranslateModule
+        TranslateModule,
+        MarkedPipe
     ]
 })
 export class SharedModule { }

--- a/client/imports/app/shared/shared.scss
+++ b/client/imports/app/shared/shared.scss
@@ -1,8 +1,12 @@
 .content-flex-container {
-    display: flex;
-    flex-direction: column;
-    padding: 18px;
-    justify-content: center;
-    max-width: 1080px;
-    margin: 0 auto;
-  }
+  display: flex;
+  flex-direction: column;
+  padding: 18px;
+  justify-content: center;
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+mat-divider {
+  margin-bottom: 10px;
+}

--- a/client/imports/app/thread/thread.component.spec.ts
+++ b/client/imports/app/thread/thread.component.spec.ts
@@ -1,0 +1,57 @@
+import '../../polyfills.spec'
+
+import { RouterTestingModule } from '@angular/router/testing'
+import { TestBed, getTestBed, async } from '@angular/core/testing'
+import { expect } from 'chai'
+import { By } from '@angular/platform-browser'
+import { TranslateModule } from '@ngx-translate/core'
+import { ThreadComponent } from './thread.component'
+import { ThreadModule } from './thread.module'
+
+describe(`ThreadComponent`, () => {
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [],
+            imports: [
+                RouterTestingModule,
+                ThreadModule,
+                TranslateModule.forRoot({ })
+            ]
+        }).compileComponents() // compile html and css
+    }))
+
+    afterEach(() => {
+        getTestBed().resetTestingModule()
+    })
+
+    it('should create the component', async(() => {
+        const fixture = TestBed.createComponent(ThreadComponent)
+        const thread = fixture.debugElement.componentInstance
+        expect(thread).to.be.ok
+    }))
+
+    // TODO: Mock the subscription (Otherwise expected to 404)
+    /*it(`should contain an '<h1>'` , async(() => {
+        const fixture = TestBed.createComponent(ThreadComponent)
+        fixture.detectChanges()
+        const heading = fixture.debugElement.query(By.css('h1'))
+
+        expect(heading).to.be.ok
+    }))
+
+    it(`should contain an '<header>'` , async(() => {
+        const fixture = TestBed.createComponent(ThreadComponent)
+        fixture.detectChanges()
+        const header = fixture.debugElement.query(By.css('header'))
+
+        expect(header).to.be.ok
+    }))
+
+    it(`should contain an '<mat-divider>'` , async(() => {
+        const fixture = TestBed.createComponent(ThreadComponent)
+        fixture.detectChanges()
+        const divider = fixture.debugElement.query(By.css('mat-divider'))
+
+        expect(divider).to.be.ok
+    }))*/
+})

--- a/client/imports/app/thread/thread.component.ts
+++ b/client/imports/app/thread/thread.component.ts
@@ -1,0 +1,57 @@
+import { Component, ChangeDetectionStrategy, OnInit, ChangeDetectorRef, OnDestroy } from '@angular/core'
+import { ActivatedRoute, Router } from '@angular/router'
+import { Observable, Subscription } from 'rxjs'
+import { Thread } from 'imports/models/thread'
+import { Threads } from 'imports/collections/threads'
+import { MeteorObservable } from 'meteor-rxjs'
+
+@Component({
+    selector: 'thread-component',
+    templateUrl: './thread.html',
+    styleUrls: [ './thread.scss' ],
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ThreadComponent implements OnInit, OnDestroy {
+    threads: Observable<Thread[]>
+    threadsListSubscription: Subscription
+    thread: Thread
+
+    constructor(
+        private changeDetectorRef: ChangeDetectorRef,
+        private route: ActivatedRoute,
+        private router: Router)        {
+        }
+
+    ngOnInit() {
+        this.getThread()
+    }
+
+    getThread() {
+        this.route.params.subscribe(params => {
+            const id = params.id
+            const forumId = params.forumId
+
+            this.threadsListSubscription = MeteorObservable.subscribe('threads').subscribe(() => {
+                this.threads = Threads.find({ _id: id }, { sort: { name: 1 } })
+                this.threads.subscribe(threads => {
+                    if (threads.length === 1) {
+                        this.thread = threads[0]
+                        this.changeDetectorRef.markForCheck()
+                    }
+                    else {
+                        if (!this.threadsListSubscription.closed) {
+                            this.router.navigateByUrl('/404')
+                        }
+                    }
+                })
+            })
+
+        })
+    }
+
+    ngOnDestroy() {
+        if (this.threadsListSubscription) {
+            this.threadsListSubscription.unsubscribe()
+        }
+    }
+}

--- a/client/imports/app/thread/thread.html
+++ b/client/imports/app/thread/thread.html
@@ -6,6 +6,6 @@
   </header>
   <mat-divider></mat-divider>
   <main>
-    
+    <posts-component [threadId]="thread?._id"></posts-component>
   </main>
 </article>

--- a/client/imports/app/thread/thread.html
+++ b/client/imports/app/thread/thread.html
@@ -1,0 +1,11 @@
+<article>
+  <header>
+    <h1>
+      {{ thread?.name }}
+    </h1>
+  </header>
+  <mat-divider></mat-divider>
+  <main>
+    
+  </main>
+</article>

--- a/client/imports/app/thread/thread.module.ts
+++ b/client/imports/app/thread/thread.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from "@angular/core"
 import { ThreadComponent } from './thread.component'
 import { SharedModule } from '../shared/shared.module'
 import { MatDividerModule } from '@angular/material/divider'
+import { PostsModule } from '../posts/posts.module'
 
 @NgModule({
     declarations: [
@@ -9,7 +10,8 @@ import { MatDividerModule } from '@angular/material/divider'
     ],
     imports: [
         SharedModule,
-        MatDividerModule
+        MatDividerModule,
+        PostsModule
     ],
     exports: [
         ThreadComponent

--- a/client/imports/app/thread/thread.module.ts
+++ b/client/imports/app/thread/thread.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from "@angular/core"
+import { ThreadComponent } from './thread.component'
+import { SharedModule } from '../shared/shared.module'
+import { MatDividerModule } from '@angular/material/divider'
+
+@NgModule({
+    declarations: [
+        ThreadComponent
+    ],
+    imports: [
+        SharedModule,
+        MatDividerModule
+    ],
+    exports: [
+        ThreadComponent
+    ]
+})
+export class ThreadModule { }

--- a/client/imports/app/thread/thread.scss
+++ b/client/imports/app/thread/thread.scss
@@ -1,0 +1,5 @@
+@import "../shared/shared";
+
+:host {
+  @extend .content-flex-container;
+}

--- a/client/imports/app/threads-widget/threads-widget.html
+++ b/client/imports/app/threads-widget/threads-widget.html
@@ -18,7 +18,7 @@
         <td>{{ thread.creator }}</td>
         <td>{{ thread.viewCounter }}</td>
         <td>{{ thread.followCounter }}</td>
-        <td>{{ thread.date }}</td>
+        <td>{{ thread.date.toLocaleString() }}</td>
       </tr>
     </tbody>
   </table>

--- a/client/imports/app/threads-widget/threads-widget.html
+++ b/client/imports/app/threads-widget/threads-widget.html
@@ -18,7 +18,7 @@
         <td>{{ thread.creator }}</td>
         <td>{{ thread.viewCounter }}</td>
         <td>{{ thread.followCounter }}</td>
-        <td>{{ thread.date.toLocaleString() }}</td>
+        <td>{{ thread.date | date: 'medium' }}</td>
       </tr>
     </tbody>
   </table>

--- a/client/imports/app/threads-widget/threads-widget.html
+++ b/client/imports/app/threads-widget/threads-widget.html
@@ -12,7 +12,7 @@
     <tbody>
       <tr
         *ngFor="let thread of threads | async; trackBy: identify"
-        routerLink="/forum/{{ forumID }}/{{ thread._id }}"
+        routerLink="/forum/{{ forumId }}/thread/{{ thread._id }}"
       >
         <td>{{ thread.name }}</td>
         <td>{{ thread.creator }}</td>

--- a/client/imports/styles/_main.scss
+++ b/client/imports/styles/_main.scss
@@ -1,6 +1,6 @@
 @import "colors";
-
-@import url("/assets/css/reset.css");
+// @import url("/assets/css/reset.css");
+@import url("/assets/css/normalize.css");
 @import url("/assets/css/typography.css");
 @import "theme";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1895,6 +1895,11 @@
         "sourcemap-codec": "^1.4.4"
       }
     },
+    "marked": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.0.tgz",
+      "integrity": "sha512-EkE7RW6KcXfMHy2PA7Jg0YJE1l8UPEZE8k45tylzmZM30/r1M1MUXWQfJlrSbsTeh7m/XTwHbWUENvAJZpp1YA=="
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "bcrypt": "^4.0.1",
     "core-js": "2.5.7",
     "lint": "^0.7.0",
+    "marked": "^1.1.0",
     "meteor-node-stubs": "1.0.0",
     "meteor-rxjs": "0.4.14",
     "rxjs": "6.5.5",

--- a/public/assets/css/normalize.css
+++ b/public/assets/css/normalize.css
@@ -1,0 +1,349 @@
+/*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
+
+/* Document
+   ========================================================================== */
+
+/**
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
+ */
+
+ html {
+    line-height: 1.15; /* 1 */
+    -webkit-text-size-adjust: 100%; /* 2 */
+  }
+  
+  /* Sections
+     ========================================================================== */
+  
+  /**
+   * Remove the margin in all browsers.
+   */
+  
+  body {
+    margin: 0;
+  }
+  
+  /**
+   * Render the `main` element consistently in IE.
+   */
+  
+  main {
+    display: block;
+  }
+  
+  /**
+   * Correct the font size and margin on `h1` elements within `section` and
+   * `article` contexts in Chrome, Firefox, and Safari.
+   */
+  
+  h1 {
+    font-size: 2em;
+    margin: 0.67em 0;
+  }
+  
+  /* Grouping content
+     ========================================================================== */
+  
+  /**
+   * 1. Add the correct box sizing in Firefox.
+   * 2. Show the overflow in Edge and IE.
+   */
+  
+  hr {
+    box-sizing: content-box; /* 1 */
+    height: 0; /* 1 */
+    overflow: visible; /* 2 */
+  }
+  
+  /**
+   * 1. Correct the inheritance and scaling of font size in all browsers.
+   * 2. Correct the odd `em` font sizing in all browsers.
+   */
+  
+  pre {
+    font-family: monospace, monospace; /* 1 */
+    font-size: 1em; /* 2 */
+  }
+  
+  /* Text-level semantics
+     ========================================================================== */
+  
+  /**
+   * Remove the gray background on active links in IE 10.
+   */
+  
+  a {
+    background-color: transparent;
+  }
+  
+  /**
+   * 1. Remove the bottom border in Chrome 57-
+   * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+   */
+  
+  abbr[title] {
+    border-bottom: none; /* 1 */
+    text-decoration: underline; /* 2 */
+    text-decoration: underline dotted; /* 2 */
+  }
+  
+  /**
+   * Add the correct font weight in Chrome, Edge, and Safari.
+   */
+  
+  b,
+  strong {
+    font-weight: bolder;
+  }
+  
+  /**
+   * 1. Correct the inheritance and scaling of font size in all browsers.
+   * 2. Correct the odd `em` font sizing in all browsers.
+   */
+  
+  code,
+  kbd,
+  samp {
+    font-family: monospace, monospace; /* 1 */
+    font-size: 1em; /* 2 */
+  }
+  
+  /**
+   * Add the correct font size in all browsers.
+   */
+  
+  small {
+    font-size: 80%;
+  }
+  
+  /**
+   * Prevent `sub` and `sup` elements from affecting the line height in
+   * all browsers.
+   */
+  
+  sub,
+  sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+  
+  sub {
+    bottom: -0.25em;
+  }
+  
+  sup {
+    top: -0.5em;
+  }
+  
+  /* Embedded content
+     ========================================================================== */
+  
+  /**
+   * Remove the border on images inside links in IE 10.
+   */
+  
+  img {
+    border-style: none;
+  }
+  
+  /* Forms
+     ========================================================================== */
+  
+  /**
+   * 1. Change the font styles in all browsers.
+   * 2. Remove the margin in Firefox and Safari.
+   */
+  
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    font-family: inherit; /* 1 */
+    font-size: 100%; /* 1 */
+    line-height: 1.15; /* 1 */
+    margin: 0; /* 2 */
+  }
+  
+  /**
+   * Show the overflow in IE.
+   * 1. Show the overflow in Edge.
+   */
+  
+  button,
+  input { /* 1 */
+    overflow: visible;
+  }
+  
+  /**
+   * Remove the inheritance of text transform in Edge, Firefox, and IE.
+   * 1. Remove the inheritance of text transform in Firefox.
+   */
+  
+  button,
+  select { /* 1 */
+    text-transform: none;
+  }
+  
+  /**
+   * Correct the inability to style clickable types in iOS and Safari.
+   */
+  
+  button,
+  [type="button"],
+  [type="reset"],
+  [type="submit"] {
+    -webkit-appearance: button;
+  }
+  
+  /**
+   * Remove the inner border and padding in Firefox.
+   */
+  
+  button::-moz-focus-inner,
+  [type="button"]::-moz-focus-inner,
+  [type="reset"]::-moz-focus-inner,
+  [type="submit"]::-moz-focus-inner {
+    border-style: none;
+    padding: 0;
+  }
+  
+  /**
+   * Restore the focus styles unset by the previous rule.
+   */
+  
+  button:-moz-focusring,
+  [type="button"]:-moz-focusring,
+  [type="reset"]:-moz-focusring,
+  [type="submit"]:-moz-focusring {
+    outline: 1px dotted ButtonText;
+  }
+  
+  /**
+   * Correct the padding in Firefox.
+   */
+  
+  fieldset {
+    padding: 0.35em 0.75em 0.625em;
+  }
+  
+  /**
+   * 1. Correct the text wrapping in Edge and IE.
+   * 2. Correct the color inheritance from `fieldset` elements in IE.
+   * 3. Remove the padding so developers are not caught out when they zero out
+   *    `fieldset` elements in all browsers.
+   */
+  
+  legend {
+    box-sizing: border-box; /* 1 */
+    color: inherit; /* 2 */
+    display: table; /* 1 */
+    max-width: 100%; /* 1 */
+    padding: 0; /* 3 */
+    white-space: normal; /* 1 */
+  }
+  
+  /**
+   * Add the correct vertical alignment in Chrome, Firefox, and Opera.
+   */
+  
+  progress {
+    vertical-align: baseline;
+  }
+  
+  /**
+   * Remove the default vertical scrollbar in IE 10+.
+   */
+  
+  textarea {
+    overflow: auto;
+  }
+  
+  /**
+   * 1. Add the correct box sizing in IE 10.
+   * 2. Remove the padding in IE 10.
+   */
+  
+  [type="checkbox"],
+  [type="radio"] {
+    box-sizing: border-box; /* 1 */
+    padding: 0; /* 2 */
+  }
+  
+  /**
+   * Correct the cursor style of increment and decrement buttons in Chrome.
+   */
+  
+  [type="number"]::-webkit-inner-spin-button,
+  [type="number"]::-webkit-outer-spin-button {
+    height: auto;
+  }
+  
+  /**
+   * 1. Correct the odd appearance in Chrome and Safari.
+   * 2. Correct the outline style in Safari.
+   */
+  
+  [type="search"] {
+    -webkit-appearance: textfield; /* 1 */
+    outline-offset: -2px; /* 2 */
+  }
+  
+  /**
+   * Remove the inner padding in Chrome and Safari on macOS.
+   */
+  
+  [type="search"]::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+  
+  /**
+   * 1. Correct the inability to style clickable types in iOS and Safari.
+   * 2. Change font properties to `inherit` in Safari.
+   */
+  
+  ::-webkit-file-upload-button {
+    -webkit-appearance: button; /* 1 */
+    font: inherit; /* 2 */
+  }
+  
+  /* Interactive
+     ========================================================================== */
+  
+  /*
+   * Add the correct display in Edge, IE 10+, and Firefox.
+   */
+  
+  details {
+    display: block;
+  }
+  
+  /*
+   * Add the correct display in all browsers.
+   */
+  
+  summary {
+    display: list-item;
+  }
+  
+  /* Misc
+     ========================================================================== */
+  
+  /**
+   * Add the correct display in IE 10+.
+   */
+  
+  template {
+    display: none;
+  }
+  
+  /**
+   * Add the correct display in IE 10.
+   */
+  
+  [hidden] {
+    display: none;
+  }

--- a/public/assets/css/typography.css
+++ b/public/assets/css/typography.css
@@ -3,11 +3,21 @@ html {
   font-style: normal;
   font-weight: normal;
   font-size: 18px;
-  line-height: 21px;
+  /*line-height: 21px;*/
 }
 
 p {
   margin-bottom: 20px;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h5,
+h6 {
+  font-weight: 400;
 }
 
 h1 {

--- a/public/assets/i18n/en.json
+++ b/public/assets/i18n/en.json
@@ -7,6 +7,12 @@
     "admin": {
       "navigateTo": "Navigate to Adminstration",
       "heading": "Administration"
+    },
+    "thread": {
+      "answers":{
+        "empty": "There aren't any answers to this thread yet.",
+        "title": "Answers"
+      }
     }
   },
   "widgets": {

--- a/public/assets/i18n/en.json
+++ b/public/assets/i18n/en.json
@@ -60,10 +60,12 @@
     },
     "actions": {
       "title": "Actions"
-    }
-    ,
-    "new-thread":{
+    },
+    "new-thread": {
       "title": "Create Thread",
+      "msg": {
+        "must-be-signed-in": "You must be signed in to start a new Thread."
+      },
       "form": {
         "inputs": {
           "title": {
@@ -77,7 +79,6 @@
             "label": "Text",
             "placeholder": "Something important..."
           }
-
         }
       },
       "alerts": {


### PR DESCRIPTION
This is another large one.

# What this PR does

This PR introduces view-able Threads. Threads show the main entry and answers. Both beautifully formatted with markdown. 😎

## Additional

This fixes #60

This also includes (As additional Module) (fixes #37):
- The main post on a thread
- The answers on a thread

I also did some style enhancements and added a Markdown-pipe (fixes #20)


[Create a module as thread-page](https://app.gitkraken.com/glo/board/5ead65ff6cb04e00112b0b5f/card/5eefd14bf951d500124c1ea6)
[Create a module for displaying posts](https://app.gitkraken.com/glo/board/5ead65ff6cb04e00112b0b5f/card/5ec329283c501600167256a8)
[Add markdown interpreter](https://app.gitkraken.com/glo/board/5ead65ff6cb04e00112b0b5f/card/5ebeecb27a583d001136af17)