### PR TITLE
Bugfix: Activated Word wrap for frame-component

### DIFF
--- a/client/imports/app/frame/frame.scss
+++ b/client/imports/app/frame/frame.scss
@@ -5,6 +5,11 @@
   width: 100%;
   padding-top: 13.5px;
   margin-bottom: 14px;
+  overflow: auto;
+  overflow-wrap: break-word;
+  white-space: normal;
+  word-break: break-word;
+  text-overflow: ellipsis;
 
   > header {
     left: 7px;


### PR DESCRIPTION
fixes #64


[`FrameComponent` allows for Overflow](https://app.gitkraken.com/glo/board/5ead65ff6cb04e00112b0b5f/card/5ef04bcbb234f30012c6552f)